### PR TITLE
Use extensions to configure plugin instead of project properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,8 @@ out
 *.iml
 src/main/java/layer/transport/thrift
 classes
+*.swp
+.settings
+.project
+.classpath
+

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Plugin can be configured by extensions instead of giving arguments via command l
 		// optional
 
 		newpublishtaskname = "publishToGihub"
-		publishTask = "publish" //(option for publishing, default is publish) The publish task to use
+		publishtask = "publish" //(option for publishing, default is publish) The publish task to use
 	}
 
 ## Flags

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This plugin needs to be added via the standard plugin mechanism with this builds
             maven { url "https://github.com/layerhq/releases-gradle/raw/master/releases" }
         }
         dependencies {
-            classpath group: 'com.layer', name: 'git-repo-plugin', version: '1.0.0'
+            classpath group: 'com.layer', name: 'git-repo-plugin', version: '1.1.0'
         }
     }
 
@@ -95,6 +95,30 @@ A version of this with the `maven` plugin might look like
             }
         }
     }
+
+## Extensions
+
+Plugin can be configured by extensions instead of giving arguments via command line
+
+    repoconfig {
+		// mendatory
+
+        org = "myorg"
+		repo = "myrepo"
+
+		// optional
+
+		provider = "github.com" // or "gitlab.com", or any other github like
+		branch = "master"
+		gitrepohome = "${System.properties['user.home']}/.gitRepos" // (default is ~/.gitRepos) The location for cloned gitrepos
+	}
+
+    taskconfig {
+		// optional
+
+		newpublishtaskname = "publishToGihub"
+		publishTask = "publish" //(option for publishing, default is publish) The publish task to use
+	}
 
 ## Flags
 

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
          maven { url "https://github.com/layerhq/releases-gradle/raw/master/releases" }
      }
      dependencies {
-         classpath group: 'com.layer', name: 'git-repo-plugin', version: '1.0.0'
+         classpath group: 'com.layer', name: 'git-repo-plugin', version: '1.1.0'
      }
 }
 
@@ -16,6 +16,11 @@ apply from: "$rootDir/version.gradle"
 dependencies {
     compile gradleApi()
     compile localGroovy()
+}
+
+repoconfig{
+	org = hasProperty("org")?project.org:"layerhq"
+	repo = hasProperty("repo")?project.repo:"gradle-releases"
 }
 
 publishing {
@@ -28,7 +33,7 @@ publishing {
     }
     repositories {
         maven {
-            url "file://${System.env.HOME}/.gitRepos/${property("org")}/${property("repo")}/releases"
+            url "file://${System.env.HOME}/.gitRepos/${repoconfig.org}/${repoconfig.repo}/releases"
         }
     }
 }

--- a/src/main/groovy/com/layer/gradle/gitrepo/GitRepoPlugin.groovy
+++ b/src/main/groovy/com/layer/gradle/gitrepo/GitRepoPlugin.groovy
@@ -14,10 +14,13 @@ class GitRepoPlugin  implements Plugin<Project> {
 
     void apply(Project project) {
 
+		project.extensions.create("repoconfig",GitRepoPluginExtension)
+		project.extensions.create("taskconfig",PublishTaskExtension)
+
         // allow declaring special repositories
         if (!project.repositories.metaClass.respondsTo(project.repositories, 'github', String, String, String, String, Object)) {
             project.repositories.metaClass.github = { String org, String repo, String branch = "master", String type = "releases", def closure = null ->
-                String gitUrl = gitCloneUrl(org, repo)
+                String gitUrl = gitCloneUrl(project)
                 def orgDir = repositoryDir(project, org)
                 addLocalRepo(project, ensureLocalRepo(project, orgDir, repo, gitUrl, branch), type)
             }
@@ -36,16 +39,16 @@ class GitRepoPlugin  implements Plugin<Project> {
                 cloneRepo.doFirst{
                     ensureLocalRepo(
                             project,
-                            repositoryDir(project, project.property("org")),
-                            project.property("repo"),
-                            gitCloneUrl(project.property("org"), project.property("repo")),
-                            project.hasProperty("branch") ? project.property("branch") : "master")
+                            repositoryDir(project, project.repoconfig.org),
+                            project.repoconfig.repo,
+                            gitCloneUrl(project),
+                            project.repoconfig.branch)
                 }
                 publishTask(project).dependsOn(cloneRepo)
 
-                Task publishToGithub = project.tasks.create("publishToGithub")
+                Task publishToGithub = project.tasks.create(project.repoconfig.taskname)
                 publishToGithub.doFirst {
-                    def gitDir = repositoryDir(project, project.property("org") + "/" + project.property("repo"))
+                    def gitDir = repositoryDir(project, project.repoconfig.org + "/" + project.repoconfig.repo)
                     project.exec {
                         executable "git"
                         workingDir gitDir
@@ -78,27 +81,28 @@ class GitRepoPlugin  implements Plugin<Project> {
     }
 
     private static Task publishTask(Project project) {
-        if(project.hasProperty("publishTask")) {
-            return project.tasks.getByName((String) project.property("publishTask"))
-        } else {
-            return project.tasks.getByName("publish")
-        }
+		project.tasks.getByName(project.taskconfig.publishTask)
     }
 
     private static File repositoryDir(Project project, String name) {
-        if(project.hasProperty("gitRepoHome")) {
-            return project.file("${project.property("gitRepoHome")}/$name")
-        } else {
-            return project.file("${System.properties['user.home']}/.gitRepos/$name")
-        }
+        return project.file("${project.repoconfig.gitrepohome}/$name")
     }
 
-    private static String gitCloneUrl(String org, String repo) {
-        return "git@github.com:$org/${repo}.git"
+    private static String gitCloneUrl(Project project) {
+		def String url = ""
+		if(project.repoconfig.giturl != ""){
+			url = project.repoconfig.giturl
+		} else {
+			url = "git@${project.repoconfig.provider}:${project.repoconfig.org}/${project.repoconfig.repo}.git"
+		}
+        return url
     }
 
     private static File ensureLocalRepo(Project project, File directory, String name, String gitUrl, String branch) {
         def repoDir = new File(directory, name)
+
+		println "Ensure local repo : dir ${directory.getAbsolutePath()}, name : ${name}, url ${gitUrl}, branch ${branch}"
+
         if(!repoDir.directory) {
             project.mkdir(directory)
             project.exec {
@@ -127,4 +131,18 @@ class GitRepoPlugin  implements Plugin<Project> {
 
     }
 
+}
+
+class GitRepoPluginExtension{
+	def String org = ""
+	def String repo = ""
+	def String provider = "github.com" //github.com, gitlab or others
+	def String giturl = "" //used to replace git@${provider}:${org}/${repo}.git
+	def String branch = "master"
+	def String gitrepohome = "${System.properties['user.home']}/.gitRepos"
+}
+
+class PublishTaskExtension{
+	def String newpublishtaskname = "publishToGithub"
+	def String publishTask = "publish" //default publish tasks added by maven-publish plugin
 }

--- a/src/main/groovy/com/layer/gradle/gitrepo/GitRepoPlugin.groovy
+++ b/src/main/groovy/com/layer/gradle/gitrepo/GitRepoPlugin.groovy
@@ -46,7 +46,7 @@ class GitRepoPlugin  implements Plugin<Project> {
                 }
                 publishTask(project).dependsOn(cloneRepo)
 
-                Task publishToGithub = project.tasks.create(project.repoconfig.taskname)
+                Task publishToGithub = project.tasks.create(project.taskconfig.newpublishtaskname)
                 publishToGithub.doFirst {
                     def gitDir = repositoryDir(project, project.repoconfig.org + "/" + project.repoconfig.repo)
                     project.exec {
@@ -81,7 +81,7 @@ class GitRepoPlugin  implements Plugin<Project> {
     }
 
     private static Task publishTask(Project project) {
-		project.tasks.getByName(project.taskconfig.publishTask)
+		project.tasks.getByName(project.taskconfig.publishtask)
     }
 
     private static File repositoryDir(Project project, String name) {
@@ -100,9 +100,6 @@ class GitRepoPlugin  implements Plugin<Project> {
 
     private static File ensureLocalRepo(Project project, File directory, String name, String gitUrl, String branch) {
         def repoDir = new File(directory, name)
-
-		println "Ensure local repo : dir ${directory.getAbsolutePath()}, name : ${name}, url ${gitUrl}, branch ${branch}"
-
         if(!repoDir.directory) {
             project.mkdir(directory)
             project.exec {
@@ -144,5 +141,5 @@ class GitRepoPluginExtension{
 
 class PublishTaskExtension{
 	def String newpublishtaskname = "publishToGithub"
-	def String publishTask = "publish" //default publish tasks added by maven-publish plugin
+	def String publishtask = "publish" //default publish tasks added by maven-publish plugin
 }

--- a/version.gradle
+++ b/version.gradle
@@ -1,1 +1,1 @@
-version='1.0.1'
+version='1.1.0'


### PR DESCRIPTION
Remove the need of using command line parameters. Used gradle extensions instead. 

Remove also the dependency to github. We can use gitlab or an other git host.