### PR TITLE
Repo Caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This plugin needs to be added via the standard plugin mechanism with this builds
             mavenCentral()
         }
         dependencies {
-            classpath group: 'com.layer', name: 'gradle-git-repo-plugin', version: '2.0.2'
+            classpath group: 'com.layer', name: 'gradle-git-repo-plugin', version: '2.1.0'
         }
     }
 
@@ -81,7 +81,7 @@ Then you can run
 
     gradle publishToGithub
 
-You can also run 
+You can also run
 
     gradle publish
 
@@ -96,7 +96,7 @@ A version of this with the `maven` plugin might look like
         String repoHome = gitPublishConfig.home
         return "file://$repoHome/$org/$repo/releases"
     }
-    
+
     task publishJar(type: Upload, description: "Upload android Jar library") {
         configuration = configurations.sdkJar
         repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -78,4 +78,3 @@ uploadArchives {
         }
     }
 }
-

--- a/src/main/groovy/com/layer/gradle/gitrepo/GitRepoPlugin.groovy
+++ b/src/main/groovy/com/layer/gradle/gitrepo/GitRepoPlugin.groovy
@@ -12,6 +12,8 @@ import org.ajoberstar.grgit.*
  * Created by drapp on 7/16/14.
  */
 class GitRepoPlugin  implements Plugin<Project> {
+    static repoCache = [:]
+
     void apply(Project project) {
 
         project.extensions.create("gitPublishConfig", GitPublishConfig)
@@ -92,7 +94,16 @@ class GitRepoPlugin  implements Plugin<Project> {
         }
     }
 
+    private static String repoCacheKey(File directory, String name, String gitUrl, String branch) {
+        return "${directory.path}:${name}:${gitUrl}:${branch}"
+    }
+
     private static File ensureLocalRepo(Project project, File directory, String name, String gitUrl, String branch) {
+        def cacheKey = repoCacheKey(directory, name, gitUrl, branch)
+        if(repoCache.containsKey(cacheKey)) {
+          return repoCache[cacheKey]
+        }
+
         def repoDir = new File(directory, name)
         def gitRepo;
         if(repoDir.directory || project.hasProperty("offline")) {
@@ -105,6 +116,8 @@ class GitRepoPlugin  implements Plugin<Project> {
             gitRepo.pull()
         }
 
+        repoCache[cacheKey] = repoDir;
+
         return repoDir;
     }
 
@@ -112,7 +125,6 @@ class GitRepoPlugin  implements Plugin<Project> {
         project.repositories.maven {
             url repoDir.getAbsolutePath() + "/" + type
         }
-
     }
 
 }

--- a/version.gradle
+++ b/version.gradle
@@ -1,1 +1,1 @@
-version='2.0.2'
+version='2.1.0'


### PR DESCRIPTION
My team has a large multi-project build where each sub-project uses the same maven git repo.  When running any gradle command, the repo is setup individually for each sub-project which causes a significant delay.  This PR caches the gradle directory in memory after it does the initial setup and pull.